### PR TITLE
add entry for Wavecake

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Awesome List of Web Bluetooth Libraries, Demos and Resources
 * [Web Bluetooth Terminal](https://github.com/1oginov/Web-Bluetooth-Terminal)
 * [Nordic Thingy:52 Web App](https://developer.nordicsemi.com/thingy/52/)
 * [Ergometer Space](https://ergometer-space.org/)
+* [Wavecake](https://app.getwavecake.com/webdevice) - IDE for sandboxing Web Bluetooth scripts
 
 ## Tutorials / Blog posts
 


### PR DESCRIPTION
Wavecake is a tool I created. It's a basic IDE that let's users sandbox web serial and web bluetooth scripts. It also supports charts. Most web IDEs don't support the google hardware APIs. If they do, they're a little overbuilt for embedded development. They emphasize HTML and CSS or javascript frameworks rather. To experiment with the web serial, the needs are much more basic. 